### PR TITLE
Default validators can't handle body == null

### DIFF
--- a/lib/lumina.js
+++ b/lib/lumina.js
@@ -106,6 +106,9 @@ Lumina.requiredBodyFieldValidator = function() {
 		}
 
 		return function(req, res, next, pass) {
+			if ( req.body == null ) {
+				return next(new restify.ForbiddenError("Must send fields: (" + fields + ")"));
+			}
 			var bodyFields = Object.keys(req.body);
 			var missingFields = fields.filter(function(a) {
 				return bodyFields.indexOf(a) == -1;
@@ -130,6 +133,10 @@ Lumina.restrictedBodyFieldValidator = function() {
 		}
 
 		return function(req, res, next, pass) {
+			console.log(req.body);
+			if ( req.body == null ) {
+				return pass();
+			}
 			var bodyFields = Object.keys(req.body);
 			var naughtyFields = fields.filter(function(a) {
 				return bodyFields.indexOf(a) != -1;
@@ -154,6 +161,9 @@ Lumina.permittedBodyFieldValidator = function() {
 		}
 
 		return function(req, res, next, pass) {
+			if ( req.body == null ) {
+				return pass();
+			}
 			var bodyFields = Object.keys(req.body);
 			var naughtyFields = bodyFields.filter(function(a) {
 				return fields.indexOf(a) == -1;

--- a/lib/lumina.js
+++ b/lib/lumina.js
@@ -133,7 +133,6 @@ Lumina.restrictedBodyFieldValidator = function() {
 		}
 
 		return function(req, res, next, pass) {
-			console.log(req.body);
 			if ( req.body == null ) {
 				return pass();
 			}

--- a/tests/test.js
+++ b/tests/test.js
@@ -21,35 +21,44 @@ module.exports = {
 		});
 	},
 	testRequiredBodyFieldValidation : function(test) {
-		test.expect(3);
+		test.expect(4);
 		request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 2, "c" : 3}}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "c" : 3}}, function(err, resp, body) {
-				test.equal(resp.statusCode, 403)
-				test.deepEqual(body, { code: "ForbiddenError", message: "Must send fields: (b)" });
-				test.done();
+			request({uri:"http://localhost:8080/validation/body", method:"PUT"}, function(err, resp, body) {
+				test.equal(resp.statusCode, 403);
+				request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "c" : 3}}, function(err, resp, body) {
+					test.equal(resp.statusCode, 403)
+					test.deepEqual(body, { code: "ForbiddenError", message: "Must send fields: (b)" });
+					test.done();
+				});
 			});
 		});
 	},
 	testRestrictedBodyFieldValidation : function(test) {
-		test.expect(3);
-		request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
+		test.expect(4);
+		request({uri:"http://localhost:8080/validation/body", method:"PUT"}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 3, "d" : 4}}, function(err, resp, body) {
-				test.equal(resp.statusCode, 403)
-				test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (d)" });
-				test.done();
+			request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
+				test.equal(resp.statusCode, 200);
+				request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 3, "d" : 4}}, function(err, resp, body) {
+					test.equal(resp.statusCode, 403)
+					test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (d)" });
+					test.done();
+				});
 			});
 		});
 	},
 	testPermittedBodyFieldValidation : function(test) {
-		test.expect(3);
+		test.expect(4);
 		request({uri:"http://localhost:8080/validation/onlybody", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/onlybody", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
-				test.equal(resp.statusCode, 403)
-				test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (f,g)" });
-				test.done();
+			request({uri:"http://localhost:8080/validation/onlybody", method:"PUT"}, function(err, resp, body) {
+				test.equal(resp.statusCode, 200);
+				request({uri:"http://localhost:8080/validation/onlybody", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
+					test.equal(resp.statusCode, 403)
+					test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (f,g)" });
+					test.done();
+				});
 			});
 		});
 	}, 

--- a/tests/test.js
+++ b/tests/test.js
@@ -22,11 +22,11 @@ module.exports = {
 	},
 	testRequiredBodyFieldValidation : function(test) {
 		test.expect(4);
-		request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 2, "c" : 3}}, function(err, resp, body) {
+		request({uri:"http://localhost:8080/validation/body/required", method:"PUT", json : { "a" : 1, "b" : 2, "c" : 3}}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/body", method:"PUT"}, function(err, resp, body) {
+			request({uri:"http://localhost:8080/validation/body/required", method:"PUT"}, function(err, resp, body) {
 				test.equal(resp.statusCode, 403);
-				request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "c" : 3}}, function(err, resp, body) {
+				request({uri:"http://localhost:8080/validation/body/required", method:"PUT", json : { "a" : 1, "c" : 3}}, function(err, resp, body) {
 					test.equal(resp.statusCode, 403)
 					test.deepEqual(body, { code: "ForbiddenError", message: "Must send fields: (b)" });
 					test.done();
@@ -36,11 +36,11 @@ module.exports = {
 	},
 	testRestrictedBodyFieldValidation : function(test) {
 		test.expect(4);
-		request({uri:"http://localhost:8080/validation/body", method:"PUT"}, function(err, resp, body) {
+		request({uri:"http://localhost:8080/validation/body/restricted", method:"PUT"}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
+			request({uri:"http://localhost:8080/validation/body/restricted", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
 				test.equal(resp.statusCode, 200);
-				request({uri:"http://localhost:8080/validation/body", method:"PUT", json : { "a" : 1, "b" : 3, "d" : 4}}, function(err, resp, body) {
+				request({uri:"http://localhost:8080/validation/body/restricted", method:"PUT", json : { "a" : 1, "b" : 3, "d" : 4}}, function(err, resp, body) {
 					test.equal(resp.statusCode, 403)
 					test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (d)" });
 					test.done();
@@ -50,11 +50,11 @@ module.exports = {
 	},
 	testPermittedBodyFieldValidation : function(test) {
 		test.expect(4);
-		request({uri:"http://localhost:8080/validation/onlybody", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
+		request({uri:"http://localhost:8080/validation/body/permitted", method:"PUT", json : { "a" : 1, "b" : 2 }}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/onlybody", method:"PUT"}, function(err, resp, body) {
+			request({uri:"http://localhost:8080/validation/body/permitted", method:"PUT"}, function(err, resp, body) {
 				test.equal(resp.statusCode, 200);
-				request({uri:"http://localhost:8080/validation/onlybody", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
+				request({uri:"http://localhost:8080/validation/body/permitted", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
 					test.equal(resp.statusCode, 403)
 					test.deepEqual(body, { code: "ForbiddenError", message: "Cannot send fields: (f,g)" });
 					test.done();
@@ -64,9 +64,9 @@ module.exports = {
 	}, 
 	testHeaderValidation : function(test) {
 		test.expect(3);
-		request({uri:"http://localhost:8080/validation/headers", method:"PUT", headers : { "x-application-key" : 1, "x-client-id" : 2 }}, function(err, resp, body) {
+		request({uri:"http://localhost:8080/validation/headers/required", method:"PUT", headers : { "x-application-key" : 1, "x-client-id" : 2 }}, function(err, resp, body) {
 			test.equal(resp.statusCode, 200);
-			request({uri:"http://localhost:8080/validation/headers", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
+			request({uri:"http://localhost:8080/validation/headers/required", method:"PUT", json : { "a" : 1, "b" : 3, "f" : 5, "g" : 9}}, function(err, resp, body) {
 				test.equal(resp.statusCode, 403)
 				test.deepEqual(body, { code: "ForbiddenError", message: "Must send headers: (x-application-key,x-client-id)" });
 				test.done();

--- a/tests/testServer.js
+++ b/tests/testServer.js
@@ -22,24 +22,35 @@ function defaultHandler(req, res, next) {
 	return next();
 }
 
-server.get('/validation/none', lumen.illuminate({
-	handler : defaultHandler
-}));
+var routes = [{
+	method: "get",
+	path: "/validation/none"
+}, {
+	method: "put",
+	path: "/validation/body/required",
+	requiredBodyFields: ["a", "b"]
+}, {
+	method: "put",
+	path: "/validation/body/restricted",
+	restrictedBodyFields: ["d", "e"]
+}, {
+	method: "put",
+	path: "/validation/body/permitted",
+	permittedBodyFields: ["a", "b"]
+}, {
+	method: "put",
+	path: "/validation/headers/required",
+	requiredHeaders: ["x-application-key", "x-client-id"]
+}]
 
-server.put("/validation/body", lumen.illuminate({
-	requiredBodyFields : ["a", "b"],
-	restrictedBodyFields : ["d", "e"],
-	handler : defaultHandler
-}));
-
-server.put("/validation/onlybody", lumen.illuminate({
-	permittedBodyFields : ["a", "b"],
-	handler : defaultHandler
-}));
-
-server.put("/validation/headers", lumen.illuminate({
-	requiredHeaders : ["x-application-key", "x-client-id"],
-	handler : defaultHandler
-}));
+for ( var i = 0; i < routes.length; ++i ) {
+	var d = routes[i];
+	var m = d.method;
+	var r = d.path;
+	delete d.method
+	delete d.path;
+	d.handler = defaultHandler;
+	server[m](r, lumen.illuminate(d));
+}
 
 module.exports = server;


### PR DESCRIPTION
Updated default handlers and their associated tests to support the fact that every once in a while, you don't have a body that you can assume is present.